### PR TITLE
Update classic-standalone.json for OpenShift4.5

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -14,7 +14,7 @@ set -eo pipefail
 # Use latest stable version of WordPress if no version is specified.
 
 if [ -z "$WORDPRESS_INSTALL_VERSION" ]; then
-  WORDPRESS_INSTALL_VERSION=$(curl -s "https://api.wordpress.org/core/version-check/1.7/?version=4.1" | python -c 'import sys, json; latest = json.load(sys.stdin)["offers"][0]; print(latest["version"] if latest["response"] == "upgrade" else "4.1")')
+  WORDPRESS_INSTALL_VERSION=$(curl -s "https://api.wordpress.org/core/version-check/1.7/?version=5.5.3" | python -c 'import sys, json; latest = json.load(sys.stdin)["offers"][0]; print(latest["version"] if latest["response"] == "upgrade" else "5.5.3")')
 fi
 
 # Download WordPress.

--- a/templates/classic-standalone.json
+++ b/templates/classic-standalone.json
@@ -75,7 +75,7 @@
         {
             "name": "MYSQL_VERSION",
             "description": "The version of the MySQL database.",
-            "value": "5.4",
+            "value": "latest",
             "required": true
         },
         {

--- a/templates/classic-standalone.json
+++ b/templates/classic-standalone.json
@@ -21,7 +21,7 @@
         {
             "name": "QUICKSTART_REPOSITORY_URL",
             "description": "The URL of the quickstart Git repository.",
-            "value": "https://github.com/openshift-evangelists/wordpress-quickstart",
+            "value": "https://github.com/mschindl/wordpress-quickstart",
             "required": true
         },
         {

--- a/templates/classic-standalone.json
+++ b/templates/classic-standalone.json
@@ -75,7 +75,7 @@
         {
             "name": "MYSQL_VERSION",
             "description": "The version of the MySQL database.",
-            "value": "latest",
+            "value": "5.4",
             "required": true
         },
         {

--- a/templates/classic-standalone.json
+++ b/templates/classic-standalone.json
@@ -75,7 +75,7 @@
         {
             "name": "MYSQL_VERSION",
             "description": "The version of the MySQL database.",
-            "value": "5.7",
+            "value": "latest",
             "required": true
         },
         {

--- a/templates/classic-standalone.json
+++ b/templates/classic-standalone.json
@@ -81,7 +81,7 @@
         {
             "name": "PHP_VERSION",
             "description": "The version of the PHP builder.",
-            "value": "7.0",
+            "value": "7.3",
             "required": true
         }
     ],


### PR DESCRIPTION
Changed PHP version from 7.0 to 7.3, because of missing image and failed deployment in OpenShift4.5.